### PR TITLE
Add dimension labels to 3D model

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 body{margin:0;overflow:hidden;background:#f0f0f0}  canvas{display:block}
 #info{position:absolute;top:8px;width:100%;text-align:center;font:14px Arial;color:#333;pointer-events:none}
 #controls{position:absolute;bottom:10px;left:10px;padding:8px 10px;background:rgba(255,255,255,.85);border-radius:6px;font:12px Arial}
+.label{color:#111;font:12px Arial;background:rgba(255,255,255,.8);padding:2px 4px;border-radius:4px}
 </style>
 </head>
 <body>
@@ -16,6 +17,7 @@ body{margin:0;overflow:hidden;background:#f0f0f0}  canvas{display:block}
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/renderers/CSS2DRenderer.js"></script>
 
 <script>
 /* ── primary dimensions (ft→m) ── */
@@ -40,6 +42,20 @@ camera.position.set(7,3,14); camera.lookAt(0,FRONT_H/2,0);
 const renderer=new THREE.WebGLRenderer({antialias:true});
 renderer.setSize(innerWidth,innerHeight); document.body.appendChild(renderer.domElement);
 
+const labelRenderer=new THREE.CSS2DRenderer();
+labelRenderer.setSize(innerWidth,innerHeight);
+labelRenderer.domElement.style.position='absolute';
+labelRenderer.domElement.style.top='0px';
+labelRenderer.domElement.style.pointerEvents='none';
+document.body.appendChild(labelRenderer.domElement);
+
+addEventListener('resize',()=>{
+  camera.aspect=innerWidth/innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(innerWidth,innerHeight);
+  labelRenderer.setSize(innerWidth,innerHeight);
+});
+
 const controls=new THREE.OrbitControls(camera,renderer.domElement); controls.enableDamping=true;
 scene.add(new THREE.AmbientLight(0xffffff,1.2));
 
@@ -57,6 +73,18 @@ function addLine(a,b){
     new THREE.BufferGeometry().setFromPoints([a,b]),
     new THREE.LineBasicMaterial({color:0xffaa00})
   ));
+}
+
+function addDimension(a,b,labelText){
+  const geo=new THREE.BufferGeometry().setFromPoints([a,b]);
+  const line=new THREE.Line(geo,new THREE.LineBasicMaterial({color:0x0000ff}));
+  scene.add(line);
+  const div=document.createElement('div');
+  div.className='label';
+  div.textContent=labelText;
+  const lbl=new THREE.CSS2DObject(div);
+  lbl.position.copy(a).add(b).multiplyScalar(0.5);
+  scene.add(lbl);
 }
 
 /* ── ground ── */
@@ -79,6 +107,22 @@ const topBar=new THREE.Mesh(new THREE.BoxGeometry(FRONT_W,0.02,0.05),postMat);
 topBar.position.set(0,FRONT_H-0.01,-DEPTH/2); scene.add(topBar);
 
 const fNet=makeNet(0x202020,FRONT_W,FRONT_H); fNet.position.set(0,FRONT_H/2,-DEPTH/2); scene.add(fNet);
+
+addDimension(
+  new THREE.Vector3(-FRONT_W/2,0,-DEPTH/2),
+  new THREE.Vector3(FRONT_W/2,0,-DEPTH/2),
+  `Width: ${(FRONT_W/FT).toFixed(1)} ft`
+);
+addDimension(
+  new THREE.Vector3(FRONT_W/2,0,-DEPTH/2),
+  new THREE.Vector3(FRONT_W/2,FRONT_H,-DEPTH/2),
+  `Height: ${(FRONT_H/FT).toFixed(1)} ft`
+);
+addDimension(
+  new THREE.Vector3(FRONT_W/2,0,-DEPTH/2),
+  new THREE.Vector3(FRONT_W/2,0,DEPTH/2),
+  `Depth: ${(DEPTH/FT).toFixed(1)} ft`
+);
 
 /* ── rear net ── */
 const rNet=makeNet(0x404040,REAR_W,REAR_H); rNet.position.set(0,REAR_H/2,DEPTH/2); scene.add(rNet);
@@ -160,6 +204,7 @@ window.addEventListener('keydown',e=>{
   requestAnimationFrame(animate);
   controls.update();
   renderer.render(scene,camera);
+  labelRenderer.render(scene,camera);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add style class for dimension labels
- include CSS2DRenderer to display labels
- draw dimension lines with measurements for width, height and depth
- render CSS2D labels and handle browser resizing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fb7cd6e7c83248996e41137398091